### PR TITLE
🩹 [Patch]: Add a `ConvertTo-Hashtable` function

### DIFF
--- a/src/public/Hashtable/ConvertTo-HashTable.ps1
+++ b/src/public/Hashtable/ConvertTo-HashTable.ps1
@@ -1,0 +1,38 @@
+﻿function ConvertTo-Hashtable {
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [PSObject]$InputObject
+    )
+
+    process {
+        if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -notlike "*") {
+            $array = @()
+            foreach ($item in $InputObject) {
+                $array += ConvertTo-Hashtable -InputObject $item
+            }
+            return $array
+        } elseif ($InputObject.PSObject.Properties.Name.Count -gt 0) {
+            $hashtable = @{}
+            foreach ($property in $InputObject.PSObject.Properties) {
+                $hashtable[$property.Name] = ConvertTo-Hashtable -InputObject $property.Value
+            }
+            return $hashtable
+        } else {
+            return $InputObject
+        }
+    }
+}
+
+$json = '{
+    "key1": "value1",
+    "key2": {
+        "nestedKey1": "nestedValue1",
+        "nestedKey2": [1, 2, 3]
+    },
+    "key3": ["item1", "item2"]
+}'
+
+$object = $json | ConvertFrom-Json
+$hashtable = ConvertTo-Hashtable -InputObject $object
+
+$hashtable

--- a/src/public/Hashtable/ConvertTo-HashTable.ps1
+++ b/src/public/Hashtable/ConvertTo-HashTable.ps1
@@ -1,11 +1,30 @@
 ﻿function ConvertTo-Hashtable {
+    <#
+    .SYNOPSIS
+    Short description
+
+    .DESCRIPTION
+    Long description
+
+    .PARAMETER InputObject
+    Parameter description
+
+    .EXAMPLE
+    An example
+
+    .NOTES
+    General notes
+    #>
     param (
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [PSObject]$InputObject
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [PSObject] $InputObject
     )
 
     process {
-        if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -notlike "*") {
+        if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -notlike '*') {
             $array = @()
             foreach ($item in $InputObject) {
                 $array += ConvertTo-Hashtable -InputObject $item
@@ -31,8 +50,6 @@ $json = '{
     },
     "key3": ["item1", "item2"]
 }'
-
-$object = $json | ConvertFrom-Json
-$hashtable = ConvertTo-Hashtable -InputObject $object
+$hashtable = $json | ConvertFrom-Json | ConvertTo-Hashtable
 
 $hashtable

--- a/src/public/Hashtable/ConvertTo-HashTable.ps1
+++ b/src/public/Hashtable/ConvertTo-HashTable.ps1
@@ -52,11 +52,11 @@
                 # Handle arrays and enumerables
                 $hashtable[$propertyName] = @()
                 foreach ($item in $propertyValue) {
-                    $hashtable[$propertyName] += ConvertTo-HashtableRecursively -InputObject $item
+                    $hashtable[$propertyName] += ConvertTo-HashTable -InputObject $item
                 }
             } elseif ($propertyValue.PSObject.Properties.Count -gt 0) {
                 # Handle nested objects
-                $hashtable[$propertyName] = ConvertTo-HashtableRecursively -InputObject $propertyValue
+                $hashtable[$propertyName] = ConvertTo-Hashtable -InputObject $propertyValue
             } else {
                 # Handle simple properties
                 $hashtable[$propertyName] = $propertyValue

--- a/tests/Utilities.Tests.ps1
+++ b/tests/Utilities.Tests.ps1
@@ -285,4 +285,160 @@ Test
             't_t' | Get-StringCasingStyle | Should -Be 'snake_case'
         }
     }
+
+    Describe 'ConvertTo-Hashtable' {
+        It 'Can convert a small data structure to a hashtable' {
+            $object = [PSCustomObject]@{
+                Name        = 'John Doe'
+                Age         = 30
+                Address     = [PSCustomObject]@{
+                    Street  = '123 Main St'
+                    City    = 'Somewhere'
+                    ZipCode = '12345'
+                }
+                Occupations = @(
+                    [PSCustomObject]@{
+                        Title   = 'Developer'
+                        Company = 'TechCorp'
+                    },
+                    [PSCustomObject]@{
+                        Title   = 'Consultant'
+                        Company = 'ConsultCorp'
+                    }
+                )
+            }
+
+            $hashtable = $object | ConvertTo-Hashtable
+            $hashtable.Name | Should -Be 'John Doe'
+            $hashtable.Age | Should -Be 30
+            $hashtable.Address.Street | Should -Be '123 Main St'
+            $hashtable.Address.City | Should -Be 'Somewhere'
+            $hashtable.Address.ZipCode | Should -Be '12345'
+            $hashtable.Occupations[0].Title | Should -Be 'Developer'
+            $hashtable.Occupations[0].Company | Should -Be 'TechCorp'
+            $hashtable.Occupations[1].Title | Should -Be 'Consultant'
+            $hashtable.Occupations[1].Company | Should -Be 'ConsultCorp'
+        }
+        It 'Can convert a bigger data structure to a hashtable' {
+            $complexObject = [PSCustomObject]@{
+                Person        = [PSCustomObject]@{
+                    FirstName      = 'Alice'
+                    LastName       = 'Smith'
+                    Age            = 28
+                    Contact        = [PSCustomObject]@{
+                        Email = 'alice.smith@example.com'
+                        Phone = [PSCustomObject]@{
+                            Home   = '555-1234'
+                            Mobile = '555-5678'
+                        }
+                    }
+                    Address        = [PSCustomObject]@{
+                        Street  = '456 Oak St'
+                        City    = 'Anytown'
+                        ZipCode = '67890'
+                        Country = 'USA'
+                    }
+                    Occupations    = @(
+                        [PSCustomObject]@{
+                            Title    = 'Software Engineer'
+                            Company  = 'TechCorp'
+                            Location = 'New York'
+                            Duration = [PSCustomObject]@{
+                                Start = '2015-06-01'
+                                End   = '2019-08-31'
+                            }
+                        },
+                        [PSCustomObject]@{
+                            Title    = 'Senior Developer'
+                            Company  = 'CodeWorks'
+                            Location = 'San Francisco'
+                            Duration = [PSCustomObject]@{
+                                Start = '2019-09-01'
+                                End   = 'Present'
+                            }
+                        }
+                    )
+                    Hobbies        = @('Reading', 'Cycling', 'Hiking')
+                    Certifications = @(
+                        [PSCustomObject]@{
+                            Name       = 'PMP'
+                            IssuedBy   = 'PMI'
+                            IssueDate  = '2020-01-15'
+                            ExpiryDate = '2023-01-15'
+                        },
+                        [PSCustomObject]@{
+                            Name       = 'AWS Certified Solutions Architect'
+                            IssuedBy   = 'Amazon Web Services'
+                            IssueDate  = '2021-03-10'
+                            ExpiryDate = '2024-03-10'
+                        }
+                    )
+                }
+                Company       = [PSCustomObject]@{
+                    Name      = 'Tech Innovations Inc.'
+                    Founded   = '2010'
+                    Industry  = 'Technology'
+                    Employees = @(
+                        [PSCustomObject]@{
+                            EmployeeID = 'E001'
+                            Name       = 'Bob Johnson'
+                            Department = 'Engineering'
+                            Title      = 'Chief Engineer'
+                            Contact    = [PSCustomObject]@{
+                                Email = 'bob.johnson@techinnovations.com'
+                                Phone = '555-9876'
+                            }
+                        },
+                        [PSCustomObject]@{
+                            EmployeeID = 'E002'
+                            Name       = 'Carol Williams'
+                            Department = 'Marketing'
+                            Title      = 'Marketing Manager'
+                            Contact    = [PSCustomObject]@{
+                                Email = 'carol.williams@techinnovations.com'
+                                Phone = '555-3456'
+                            }
+                        }
+                    )
+                }
+                Projects      = @(
+                    [PSCustomObject]@{
+                        ProjectName = 'Project Phoenix'
+                        Budget      = 500000
+                        TeamMembers = @('Alice', 'Bob', 'Carol')
+                        Status      = 'In Progress'
+                    },
+                    [PSCustomObject]@{
+                        ProjectName = 'Project Orion'
+                        Budget      = 750000
+                        TeamMembers = @('Alice', 'Dave', 'Eve')
+                        Status      = 'Completed'
+                    }
+                )
+                Miscellaneous = [PSCustomObject]@{
+                    Notes       = @(
+                        'This is a sample note.',
+                        'Remember to update the project timeline.',
+                        'Check on budget allocations next quarter.'
+                    )
+                    Attachments = @(
+                        [PSCustomObject]@{
+                            FileName = 'budget_report_q1.pdf'
+                            FileSize = '1.2MB'
+                        },
+                        [PSCustomObject]@{
+                            FileName = 'project_plan.docx'
+                            FileSize = '350KB'
+                        }
+                    )
+                }
+            }
+            $hashtable = ConvertTo-Hashtable -InputObject $complexObject
+            $hashtable.Name | Should -Be 'Alice'
+            $hashtable.Contact.Email | Should -Be 'alice.smith@example.com'
+            $hashtable.Contact.Phone.Home | Should -Be '555-1234'
+            $hashtable.Hobbies | Should -Contain 'Hiking'
+            $hashtable.Certifications[0].Name | Should -Be 'PMP'
+        }
+    }
 }

--- a/tests/Utilities.Tests.ps1
+++ b/tests/Utilities.Tests.ps1
@@ -434,11 +434,16 @@ Test
                 }
             }
             $hashtable = ConvertTo-Hashtable -InputObject $complexObject
-            $hashtable.Name | Should -Be 'Alice'
-            $hashtable.Contact.Email | Should -Be 'alice.smith@example.com'
-            $hashtable.Contact.Phone.Home | Should -Be '555-1234'
-            $hashtable.Hobbies | Should -Contain 'Hiking'
-            $hashtable.Certifications[0].Name | Should -Be 'PMP'
+            $hashtable | Should -BeOfType 'Hashtable'
+            $hashtable.Keys | Should -Contain 'Person'
+            $hashtable.Keys | Should -Contain 'Company'
+            $hashtable.Keys | Should -Contain 'Projects'
+            $hashtable.Keys | Should -Contain 'Miscellaneous'
+            $hashtable.Person.FirstName | Should -Be 'Alice'
+            $hashtable.Person.Contact.Email | Should -Be 'alice.smith@example.com'
+            $hashtable.Person.Contact.Phone.Home | Should -Be '555-1234'
+            $hashtable.Person.Hobbies | Should -Contain 'Hiking'
+            $hashtable.Person.Certifications.count | Should -Be 2
         }
     }
 }


### PR DESCRIPTION
## Description

- Windows PowerShell does not support `ConvertFrom-Json -AsHashtable`. As an alternative to this i add the `ConvertTo-Hashtable` to make it possible by altering the calling command slightly. Instead you can now call `ConvertFrom-Json | ConvertTo-Hashtable`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
