### PR TITLE
🪲 [Fix]: Base64 and show files on host

### DIFF
--- a/src/functions/public/Base64/ConvertFrom-Base64.ps1
+++ b/src/functions/public/Base64/ConvertFrom-Base64.ps1
@@ -1,0 +1,24 @@
+﻿function ConvertFrom-Base64 {
+    <#
+        .SYNOPSIS
+        Converts a Base64 encoded string to a string.
+
+        .DESCRIPTION
+        Converts a Base64 encoded string to a string.
+
+        .EXAMPLE
+        ConvertFrom-Base64 -Base64String 'VGhpc0lzQU5pY2VTdHJpbmc='
+        ThisIsANiceString
+
+        Converts the Base64 encoded string 'VGhpc0lzQU5pY2VTdHJpbmc=' to a string.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        # The Base64 encoded string to convert.
+        [Parameter(Mandatory = $true)]
+        [string] $Base64String
+    )
+
+    [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($Base64String))
+}

--- a/src/functions/public/Base64/ConvertFrom-Base64.ps1
+++ b/src/functions/public/Base64/ConvertFrom-Base64.ps1
@@ -15,7 +15,7 @@
     [OutputType([string])]
     [CmdletBinding()]
     param(
-        # The Base64 encoded string to convert.
+        # The base64 encoded string to convert.
         [Parameter(Mandatory = $true)]
         [string] $Base64String
     )

--- a/src/functions/public/Base64/ConvertFrom-Base64.ps1
+++ b/src/functions/public/Base64/ConvertFrom-Base64.ps1
@@ -1,16 +1,16 @@
 ﻿function ConvertFrom-Base64 {
     <#
         .SYNOPSIS
-        Converts a Base64 encoded string to a string.
+        Converts a base64 encoded string to a string.
 
         .DESCRIPTION
-        Converts a Base64 encoded string to a string.
+        Converts a base64 encoded string to a string.
 
         .EXAMPLE
         ConvertFrom-Base64 -Base64String 'VGhpc0lzQU5pY2VTdHJpbmc='
         ThisIsANiceString
 
-        Converts the Base64 encoded string 'VGhpc0lzQU5pY2VTdHJpbmc=' to a string.
+        Converts the base64 encoded string 'VGhpc0lzQU5pY2VTdHJpbmc=' to a string.
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/Base64/ConvertTo-Base64.ps1
+++ b/src/functions/public/Base64/ConvertTo-Base64.ps1
@@ -1,0 +1,23 @@
+﻿function ConvertTo-Base64 {
+    <#
+        .SYNOPSIS
+        Converts a string to a Base64 encoded string.
+
+        .DESCRIPTION
+        Converts a string to a Base64 encoded string.
+
+        .EXAMPLE
+        ConvertTo-Base64 -String 'ThisIsANiceString'
+        VGhpc0lzQU5pY2VTdHJpbmc=
+
+        Converts the string 'ThisIsANiceString' to a Base64 encoded string.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string] $String
+    )
+
+    [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($String))
+}

--- a/src/functions/public/Base64/ConvertTo-Base64.ps1
+++ b/src/functions/public/Base64/ConvertTo-Base64.ps1
@@ -1,16 +1,16 @@
 ﻿function ConvertTo-Base64 {
     <#
         .SYNOPSIS
-        Converts a string to a Base64 encoded string.
+        Converts a string to a base64 encoded string.
 
         .DESCRIPTION
-        Converts a string to a Base64 encoded string.
+        Converts a string to a base64 encoded string.
 
         .EXAMPLE
         ConvertTo-Base64 -String 'ThisIsANiceString'
         VGhpc0lzQU5pY2VTdHJpbmc=
 
-        Converts the string 'ThisIsANiceString' to a Base64 encoded string.
+        Converts the string 'ThisIsANiceString' to a base64 encoded string.
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/Base64/ConvertTo-Base64.ps1
+++ b/src/functions/public/Base64/ConvertTo-Base64.ps1
@@ -15,6 +15,7 @@
     [OutputType([string])]
     [CmdletBinding()]
     param (
+        # The string to convert to base64
         [Parameter(Mandatory)]
         [string] $String
     )

--- a/src/functions/public/Base64/Test-Base64.ps1
+++ b/src/functions/public/Base64/Test-Base64.ps1
@@ -1,0 +1,26 @@
+﻿function Test-Base64 {
+    <#
+        .SYNOPSIS
+        Test if a string is a valid Base64 string.
+
+        .DESCRIPTION
+        Test if a string is a valid Base64 string.
+
+        .EXAMPLE
+        Test-Base64 -Base64String 'U29tZSBkYXRh'
+        True
+
+        Returns $true as the string is a valid Base64 string.
+    #>
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param (
+        [string] $Base64String
+    )
+    try {
+        $null = [Convert]::FromBase64String($Base64String)
+        return $true
+    } catch {
+        return $false
+    }
+}

--- a/src/functions/public/Base64/Test-Base64.ps1
+++ b/src/functions/public/Base64/Test-Base64.ps1
@@ -15,6 +15,8 @@
     [OutputType([bool])]
     [CmdletBinding()]
     param (
+        # The base64 encoded string to test.
+        [Parameter(Mandatory)]
         [string] $Base64String
     )
     try {

--- a/src/functions/public/Base64/Test-Base64.ps1
+++ b/src/functions/public/Base64/Test-Base64.ps1
@@ -1,16 +1,16 @@
 ﻿function Test-Base64 {
     <#
         .SYNOPSIS
-        Test if a string is a valid Base64 string.
+        Test if a string is a valid base64 string.
 
         .DESCRIPTION
-        Test if a string is a valid Base64 string.
+        Test if a string is a valid base64 string.
 
         .EXAMPLE
         Test-Base64 -Base64String 'U29tZSBkYXRh'
         True
 
-        Returns $true as the string is a valid Base64 string.
+        Returns $true as the string is a valid base64 string.
     #>
     [OutputType([bool])]
     [CmdletBinding()]

--- a/src/functions/public/Files/Show-FileContent.ps1
+++ b/src/functions/public/Files/Show-FileContent.ps1
@@ -7,7 +7,7 @@
         Prints the content of a file with line numbers in front of each line.
 
         .EXAMPLE
-        $Path = 'C:\Repos\GitHub\PSModule\Framework\PSModule.FX\src\PSModule.FX\private\Utilities\Show-FileContent.ps1'
+        $Path = 'C:\Utilities\Show-FileContent.ps1'
         Show-FileContent -Path $Path
 
         Shows the content of the file with line numbers in front of each line.

--- a/src/functions/public/Files/Show-FileContent.ps1
+++ b/src/functions/public/Files/Show-FileContent.ps1
@@ -16,7 +16,7 @@
     param (
         # The path to the file to show the content of.
         [Parameter(Mandatory)]
-        [string]$Path
+        [string] $Path
     )
 
     $content = Get-Content -Path $Path
@@ -26,7 +26,7 @@
     # The linenumber should dynamically adjust to the number of digits with the length of the file.
     foreach ($line in $content) {
         $lineNumberFormatted = $lineNumber.ToString().PadLeft($columnSize)
-        Write-Host '[{0}] {1}' -f $lineNumberFormatted, $line
+        Write-Host "[$lineNumberFormatted] $line"
         $lineNumber++
     }
 }

--- a/src/functions/public/Files/Show-FileContent.ps1
+++ b/src/functions/public/Files/Show-FileContent.ps1
@@ -26,7 +26,7 @@
     # The linenumber should dynamically adjust to the number of digits with the length of the file.
     foreach ($line in $content) {
         $lineNumberFormatted = $lineNumber.ToString().PadLeft($columnSize)
-        '[{0}] {1}' -f $lineNumberFormatted, $line
+        Write-Host '[{0}] {1}' -f $lineNumberFormatted, $line
         $lineNumber++
     }
 }


### PR DESCRIPTION
## Description

This pull request introduces several new PowerShell functions for Base64 encoding and decoding, as well as a minor update to an existing file content display function. The most important changes include the addition of three new functions for Base64 operations and a modification to the `Show-FileContent` function to use `Write-Host`.

### New Base64 Functions:

* [`src/functions/public/Base64/ConvertFrom-Base64.ps1`](diffhunk://#diff-f4a025080ef7de3f1252eb0f6c962b8c4a7ae9436929eb6aea500c8357e650d6R1-R24): Added a new function `ConvertFrom-Base64` to convert a Base64 encoded string to a regular string.
* [`src/functions/public/Base64/ConvertTo-Base64.ps1`](diffhunk://#diff-6bd8dc56f742df93ae23ac26e58a028c4ef6dc664f3d994a195f7069021995d2R1-R23): Added a new function `ConvertTo-Base64` to convert a regular string to a Base64 encoded string.
* [`src/functions/public/Base64/Test-Base64.ps1`](diffhunk://#diff-2cf7c7018923286250348248fa89bf0811869774e95aec4814296090e1242c48R1-R26): Added a new function `Test-Base64` to check if a string is a valid Base64 encoded string.

### Update to Existing Function:

* [`src/functions/public/Files/Show-FileContent.ps1`](diffhunk://#diff-123988de399ad37f4694e6a1fa20fb3f8cee97a12400398f0ba87ef30bb6cab4L29-R29): Modified the `Show-FileContent` function to use `Write-Host` for outputting the formatted line number and content.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
