### PR TITLE
🩹 [Patch]: Escape single quotes in `Convert-HashtableToString` function

### DIFF
--- a/src/functions/public/Hashtable/Convert-HashtableToString.ps1
+++ b/src/functions/public/Hashtable/Convert-HashtableToString.ps1
@@ -93,6 +93,7 @@
                 $lines += "$indent    )"
             }
         } else {
+            $value = $value -replace "('+)", "''" # Escape single quotes in a manifest file
             $lines += "$indent    $key = '$value'"
         }
     }


### PR DESCRIPTION
## Description

This pull request includes a change to the `Convert-HashtableToString.ps1` script to handle escaping of single quotes in manifest files.

* [`src/functions/public/Hashtable/Convert-HashtableToString.ps1`](diffhunk://#diff-60fc15aad7d10c312fe92888c7671d146b16b1d744d2edb739fdbbd55d0a1135R96): Added code to escape single quotes in a manifest file by replacing single quotes with double single quotes.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
