### PR TITLE
🪲 [Fix]: Remove old inputs to workflows

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -28,5 +28,3 @@ jobs:
   Process-PSModule:
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v4
     secrets: inherit
-    with:
-      Skip: SourceCode

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -29,4 +29,4 @@ jobs:
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v4
     secrets: inherit
     with:
-      SkipTests: SourceCode
+      Skip: SourceCode

--- a/src/functions/public/Boolean/ConvertTo-Boolean.ps1
+++ b/src/functions/public/Boolean/ConvertTo-Boolean.ps1
@@ -30,3 +30,5 @@
         default { $false }
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Files/Get-FileInfo.ps1
+++ b/src/functions/public/Files/Get-FileInfo.ps1
@@ -49,3 +49,5 @@
     }
     return $fileDetails
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Files/Remove-EmptyFolder.ps1
+++ b/src/functions/public/Files/Remove-EmptyFolder.ps1
@@ -28,3 +28,5 @@
         }
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Files/Show-FileContent.ps1
+++ b/src/functions/public/Files/Show-FileContent.ps1
@@ -30,3 +30,5 @@
         $lineNumber++
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Git/Clear-GitRepo.ps1
+++ b/src/functions/public/Git/Clear-GitRepo.ps1
@@ -18,3 +18,5 @@
     git fetch --all --prune
     (git branch).Trim() | Where-Object { $_ -notmatch 'main|\*' } | ForEach-Object { git branch $_ --delete --force }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Git/Invoke-GitSquash.ps1
+++ b/src/functions/public/Git/Invoke-GitSquash.ps1
@@ -39,3 +39,5 @@
     git push --force
     git checkout $TempBranchName
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Git/Invoke-SquashBranch.ps1
+++ b/src/functions/public/Git/Invoke-SquashBranch.ps1
@@ -18,3 +18,5 @@
     )
     git reset $(git merge-base $BranchName $(git branch --show-current))
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Git/Reset-GitRepo.ps1
+++ b/src/functions/public/Git/Reset-GitRepo.ps1
@@ -39,3 +39,5 @@
         }
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Git/Restore-GitRepo.ps1
+++ b/src/functions/public/Git/Restore-GitRepo.ps1
@@ -21,3 +21,5 @@
     git fetch upstream
     git restore --source upstream/$BranchName * ':!*global.variables.*' ':!settings.json*'
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Git/Sync-GitRepo.ps1
+++ b/src/functions/public/Git/Sync-GitRepo.ps1
@@ -9,6 +9,7 @@
         .EXAMPLE
         Sync-GitRepo
     #>
+    [Alias('Sync-Git')]
     [OutputType([void])]
     [CmdletBinding()]
     param()
@@ -16,4 +17,5 @@
     git pull
     git push
 }
-Set-Alias -Name sync -Value Sync-Git
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Git/Sync-Repo.ps1
+++ b/src/functions/public/Git/Sync-Repo.ps1
@@ -17,3 +17,5 @@
     git remote update origin --prune
     git branch -vv | Select-String -Pattern ': gone]' | ForEach-Object { $_.toString().Trim().Split(' ')[0] } | ForEach-Object { git branch -D $_ }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Add-ModuleManifestData.ps1
+++ b/src/functions/public/PowerShell/Module/Add-ModuleManifestData.ps1
@@ -162,3 +162,5 @@
     Set-ModuleManifest -Path $Path @changes
 
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Add-PSModulePath.ps1
+++ b/src/functions/public/PowerShell/Module/Add-PSModulePath.ps1
@@ -27,3 +27,5 @@
         Write-Verbose " - [$_]"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Export-PowerShellDataFile.ps1
+++ b/src/functions/public/PowerShell/Module/Export-PowerShellDataFile.ps1
@@ -30,3 +30,5 @@ function Export-PowerShellDataFile {
     $content | Out-File -FilePath $Path -Force:$Force
     Format-ModuleManifest -Path $Path
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Format-ModuleManifest.ps1
+++ b/src/functions/public/PowerShell/Module/Format-ModuleManifest.ps1
@@ -33,3 +33,5 @@
 
     [System.IO.File]::WriteAllText($Path, $content, $Utf8BomEncoding)
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Get-ModuleManifest.ps1
+++ b/src/functions/public/PowerShell/Module/Get-ModuleManifest.ps1
@@ -119,3 +119,5 @@
         }
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Invoke-PruneModule.ps1
+++ b/src/functions/public/PowerShell/Module/Invoke-PruneModule.ps1
@@ -58,3 +58,5 @@ function Invoke-PruneModule {
         }
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Invoke-ReinstallModule.ps1
+++ b/src/functions/public/PowerShell/Module/Invoke-ReinstallModule.ps1
@@ -61,3 +61,5 @@ function Invoke-ReinstallModule {
         Install-Module -Name $_ -Scope $Scope -Force
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Set-ModuleManifest.ps1
+++ b/src/functions/public/PowerShell/Module/Set-ModuleManifest.ps1
@@ -413,3 +413,5 @@
     Remove-Item -Path $Path -Force
     Export-PowerShellDataFile -Hashtable $outManifest -Path $Path
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Set-ScriptFileRequirement.ps1
+++ b/src/functions/public/PowerShell/Module/Set-ScriptFileRequirement.ps1
@@ -218,3 +218,5 @@ function Set-ScriptFileRequirement {
 
     Write-Verbose 'All .ps1 files processed.'
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Module/Uninstall-Pester.ps1
+++ b/src/functions/public/PowerShell/Module/Uninstall-Pester.ps1
@@ -52,3 +52,5 @@
         Remove-Item -Path $pesterPath -Recurse -Force -Confirm:$false
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/PowerShell/Object/Copy-Object.ps1
+++ b/src/functions/public/PowerShell/Object/Copy-Object.ps1
@@ -25,3 +25,5 @@
     $InputObject | ConvertTo-Json -Depth 100 | ConvertFrom-Json
 
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/String/Test-IsNotNullOrEmpty.ps1
+++ b/src/functions/public/String/Test-IsNotNullOrEmpty.ps1
@@ -27,3 +27,5 @@
     return -not ($Object | IsNullOrEmpty)
 
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/String/Test-IsNullOrEmpty.ps1
+++ b/src/functions/public/String/Test-IsNullOrEmpty.ps1
@@ -82,3 +82,5 @@
     Write-Debug 'Object is not null or empty'
     return $false
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Windows/Set-WindowsSetting.ps1
+++ b/src/functions/public/Windows/Set-WindowsSetting.ps1
@@ -35,3 +35,5 @@
     $Shell = New-Object -ComObject Shell.Application
     $Shell.Windows() | ForEach-Object { $_.Refresh() }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR


### PR DESCRIPTION
## Description

This pull request makes a small change to the `.github/workflows/Process-PSModule.yml` file by removing the `with` block, which previously specified `SkipTests: SourceCode`. This simplifies the workflow configuration.

- Remove inputs from the `.github/workflows/Process-PSModule.yml` workflow.
- Add skips for PSModule test for functions that are not covered by tests.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
